### PR TITLE
Fix options for data sent to UI

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -80,17 +80,17 @@ onNet('screenshot_basic:requestScreenshot', (options: any, url: string) => {
 });
 
 onNet('screenshot_basic:requestVideo', (options: any, url: string) => {
-    options.isVideo = true;
-    options.duration = options.duration || 1000;
-    options.encoding = options.encoding || 'webm';
-
-    options.targetURL = `http://${GetCurrentServerEndpoint()}${url}`;
-    options.targetField = 'file';
-    options.resultURL = null;
-
-    options.correlation = registerCorrelation(() => { });
-
+    const realOptions = {
+        isVideo: true,
+        duration: options.duration || 1000,
+        encoding: options.encoding || 'webm',
+        targetURL: `http://${GetCurrentServerEndpoint()}${url}`,
+        targetField: 'file',
+        resultURL: false,
+        correlation: registerCorrelation(() => { })
+    };
+    
     SendNuiMessage(JSON.stringify({
-        request: options
+        request: realOptions
     }));
 });


### PR DESCRIPTION
This will allow screenshot_basic:requestVideo to actually work correctly. The original code would not receive the options, and would cause the server export "requestClientVideo" to not send any requests back to the server when fileName is nil. Since the readme states that an undefined fileName should return a data uri this is the incorrect behavior. I've submitted a pull request to the original repo for the same reason for requestScreenshot